### PR TITLE
Handle missing Categoria column

### DIFF
--- a/inventory_price_parser_app.py
+++ b/inventory_price_parser_app.py
@@ -221,6 +221,11 @@ if inventory_df is None or purchase_df is None:
 # ---------------------------------------------------------
 merged_df = get_merged_inventory(inventory_df, purchase_df, parse_option)
 
+# Verifica che la colonna "Categoria" sia presente e popolata
+if "Categoria" not in merged_df.columns or merged_df["Categoria"].dropna().empty:
+    st.error("⚠️ Il file prezzi non contiene la colonna 'Categoria'.")
+    st.stop()
+
 with st.sidebar:
     st.subheader("⚙️ Parametri commissioni")
 


### PR DESCRIPTION
## Summary
- check whether 'Categoria' is present and not empty after merging
- show an error and stop if the column is missing or empty

## Testing
- `python -m py_compile inventory_price_parser_app.py`

------
https://chatgpt.com/codex/tasks/task_e_687c1e44aed88320ac6adf6d12b42312