### PR TITLE
Improve category selection logic

### DIFF
--- a/inventory_price_parser_app.py
+++ b/inventory_price_parser_app.py
@@ -221,16 +221,28 @@ if inventory_df is None or purchase_df is None:
 # ---------------------------------------------------------
 merged_df = get_merged_inventory(inventory_df, purchase_df, parse_option)
 
-# Verifica che la colonna "Categoria" sia presente e popolata
-if "Categoria" not in merged_df.columns or merged_df["Categoria"].dropna().empty:
-    st.error("⚠️ Il file prezzi non contiene la colonna 'Categoria'.")
-    st.stop()
+# Verifica disponibilità della colonna "Categoria" per proporre le percentuali
+cat_column_available = (
+    "Categoria" in merged_df.columns
+    and not merged_df["Categoria"].dropna().empty
+)
+if not cat_column_available:
+    st.warning(
+        "⚠️ Il file prezzi non contiene una colonna 'Categoria' valida. "
+        "Seleziona manualmente la categoria da usare."
+    )
 
 with st.sidebar:
     st.subheader("⚙️ Parametri commissioni")
 
-    cats = merged_df["Categoria"].dropna().unique().tolist()
+    if cat_column_available:
+        cats = merged_df["Categoria"].dropna().unique().tolist()
+    else:
+        cats = [c for c in CATEGORY_MAP.keys() if c != "_default"]
     selected_cat = st.selectbox("Categoria", cats)
+    if not cat_column_available:
+        # Forza la categoria selezionata per tutte le righe
+        merged_df["Categoria"] = selected_cat
 
     defaults = CATEGORY_MAP.get(selected_cat, CATEGORY_MAP["_default"])
     referral_fee_pct = st.number_input(


### PR DESCRIPTION
## Summary
- allow manual selection of category when no `Categoria` column exists in the uploaded price file
- fill the dataframe with the chosen category so calculations still work

## Testing
- `python -m py_compile inventory_price_parser_app.py`

------
https://chatgpt.com/codex/tasks/task_e_687c237cbdf083209eea8504523ae93c