### PR TITLE
Fix calc_min_price parameter name

### DIFF
--- a/inventory_price_parser_app.py
+++ b/inventory_price_parser_app.py
@@ -288,7 +288,7 @@ merged_df["Prezzo minimo suggerito (€)"] = merged_df.apply(
     closing_fee=closing_fee,
     dst_pct=DST_PCT,
     ship_cost=shipping_cost,
-    vat=vat_pct,
+    vat_pct=vat_pct,
     margin_pct=margin_pct,
 )
 


### PR DESCRIPTION
## Summary
- pass `vat_pct` keyword correctly when calculating minimum price

## Testing
- `python -m py_compile inventory_price_parser_app.py`


------
https://chatgpt.com/codex/tasks/task_e_687c2fa901108320b3e1d1b0511deed4