### PR TITLE
Fix SKU editing sync in inventory editor

### DIFF
--- a/inventory_price_parser_app.py
+++ b/inventory_price_parser_app.py
@@ -115,6 +115,11 @@ def get_merged_inventory(
     inv_key = st.selectbox("Colonna SKU in inventario", inv_key_candidates, index=0)
     price_key = st.selectbox("Colonna SKU in prezzi", price_key_candidates, index=0)
 
+    # Assicura che gli SKU siano gestiti come testo, evitando problemi di
+    # conversione numerica durante l'editing nella griglia dei risultati.
+    inventory_df[inv_key] = inventory_df[inv_key].astype(str)
+    purchase_df[price_key] = purchase_df[price_key].astype(str)
+
     inventory_df["_SKU_KEY_"] = normalize_sku(inventory_df[inv_key], parse_suffix)
     purchase_df["_SKU_KEY_"] = normalize_sku(purchase_df[price_key], parse_suffix)
 
@@ -308,7 +313,12 @@ edited_df = st.data_editor(
     key="merged_df_editor",
     use_container_width=True,
     hide_index=True,
+    column_config={
+        inv_key: st.column_config.TextColumn(disabled=False)
+    },
 )
+
+edited_df["_SKU_KEY_"] = normalize_sku(edited_df[inv_key], parse_option)
 
 if st.button("🔄 Ricalcola prezzi minimi"):
     edited_df["Prezzo minimo suggerito (€)"] = edited_df.apply(


### PR DESCRIPTION
## Summary
- keep SKU keys normalized after edits
- enable editing for SKU column in the data grid
- convert SKU columns to text to allow editing

## Testing
- `python -m py_compile inventory_price_parser_app.py`


------
https://chatgpt.com/codex/tasks/task_e_688366b2a77483208984ba922669ac0f