### PR TITLE
Add encoding fallback for load_excel

### DIFF
--- a/inventory_price_parser_app.py
+++ b/inventory_price_parser_app.py
@@ -81,7 +81,12 @@ def load_excel(uploaded_file):
 
     filename = getattr(uploaded_file, "name", "").lower()
     if filename.endswith(".txt"):
-        return pd.read_csv(uploaded_file, sep="\t", encoding="utf-8")
+        try:
+            return pd.read_csv(uploaded_file, sep="\t", encoding="utf-8")
+        except UnicodeDecodeError:
+            uploaded_file.seek(0)
+            # alcuni file .txt esportati da Excel non sono UTF-8
+            return pd.read_csv(uploaded_file, sep="\t", encoding="latin-1")
 
     return pd.read_excel(uploaded_file)
 


### PR DESCRIPTION
## Summary
- improve TXT parsing in `load_excel`
- handle `UnicodeDecodeError` and retry with Latin-1

## Testing
- `python -m py_compile inventory_price_parser_app.py`

------
https://chatgpt.com/codex/tasks/task_e_6888e6d23800832088bff473785f8adb