### PR TITLE
Update highlight comparison

### DIFF
--- a/inventory_price_parser_app.py
+++ b/inventory_price_parser_app.py
@@ -11,6 +11,7 @@
 import io
 
 import pandas as pd
+import numpy as np
 import streamlit as st
 
 CATEGORY_MAP = {
@@ -256,11 +257,9 @@ def make_flatfile_bytes(df: pd.DataFrame) -> io.BytesIO:
 
 
 def highlight_below(row):
-    if (
-        pd.notna(row.get("Prezzo minimo suggerito (€)"))
-        and pd.notna(row.get("Prezzo"))
-        and row["Prezzo minimo suggerito (€)"] < row["Prezzo"]
-    ):
+    min_val = pd.to_numeric(row.get("Prezzo minimo suggerito (€)"), errors="coerce")
+    price_val = pd.to_numeric(row.get("Prezzo"), errors="coerce")
+    if np.isfinite(min_val) and np.isfinite(price_val) and min_val < price_val:
         return ["background-color: lightcoral"] * len(row)
     return [""] * len(row)
 


### PR DESCRIPTION
## Summary
- flag entries where the suggested minimum price is below the actual price
- support numeric comparisons with coercion and finite checks

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888eae012f0832089b92fcfaa4a9fec