### PR TITLE
Fix numeric multiplication error

### DIFF
--- a/inventory_price_parser_app.py
+++ b/inventory_price_parser_app.py
@@ -371,10 +371,9 @@ with col2:
         round(edited_df["Prezzo medio acquisto (€)"].mean(skipna=True), 2),
     )
 with col3:
-    totale_vendita = round(
-        (edited_df["Prezzo"] * edited_df["Quantita'"]).sum(),
-        2,
-    )
+    price_numeric = pd.to_numeric(edited_df.get("Prezzo"), errors="coerce")
+    qty_numeric = pd.to_numeric(edited_df.get("Quantita'"), errors="coerce")
+    totale_vendita = round((price_numeric * qty_numeric).sum(), 2)
     st.metric(
         "Totale inventario (valore vendita)",
         f"€ {totale_vendita:,.2f}",


### PR DESCRIPTION
## Summary
- coerce numeric fields when calculating total inventory value

## Testing
- `python -m py_compile inventory_price_parser_app.py`

------
https://chatgpt.com/codex/tasks/task_e_688a074bd82c8320835a1a9f66ef23a1