### PR TITLE
Allow purchases TXT files

### DIFF
--- a/inventory_price_parser_app.py
+++ b/inventory_price_parser_app.py
@@ -1,8 +1,8 @@
 # inventory_price_parser_app.py
 # ---------------------------------------------------------
 # Streamlit web‑app per caricare un file inventario (ITALIA.xlsx
-# o inventario.txt) e un file prezzi d'acquisto (PREZZI ACQUISTO.xlsx)
-# e abbinarli
+# o inventario.txt) e un file prezzi d'acquisto (PREZZI ACQUISTO.xlsx
+# o acquisti.txt) e abbinarli
 # tramite SKU. Il prezzo di riferimento usato è "Prezzo medio".
 # Esecuzione locale:  
 #   streamlit run inventory_price_parser_app.py
@@ -63,8 +63,8 @@ with st.sidebar:
     )
 
     price_file = st.file_uploader(
-        "📥 File acquisti (es. PREZZI ACQUISTO.xlsx)",
-        type=["xlsx", "xls"],
+        "📥 File acquisti (es. PREZZI ACQUISTO.xlsx o acquisti.txt)",
+        type=["xlsx", "xls", "txt"],
         key="price_uploader",
     )
 


### PR DESCRIPTION
## Summary
- support tab-delimited TXT for 'file acquisti' like for inventory

## Testing
- `python -m py_compile inventory_price_parser_app.py`

------
https://chatgpt.com/codex/tasks/task_e_688a0799ad3483209ae5beaf1da7074e