### PR TITLE
Do not override dataset categories

### DIFF
--- a/inventory_price_parser_app.py
+++ b/inventory_price_parser_app.py
@@ -295,8 +295,7 @@ with st.sidebar:
 
     cats = [c for c in CATEGORY_MAP.keys() if c != "_default"]
     selected_cat = st.selectbox("Categoria", cats)
-    # Applica la stessa categoria a tutte le righe
-    merged_df["Categoria"] = selected_cat
+    # il selettore serve solo per preimpostare le commissioni
 
     defaults = CATEGORY_MAP.get(selected_cat, CATEGORY_MAP["_default"])
     referral_fee_pct = st.number_input(


### PR DESCRIPTION
## Summary
- keep any `Categoria` column from the dataset
- use the sidebar category selector only to set Amazon commission defaults

## Testing
- `python -m py_compile inventory_price_parser_app.py`

------
https://chatgpt.com/codex/tasks/task_e_688acce2e3648320869734715027c24f